### PR TITLE
GCC 11 now defines __rdtsc so make definition test conditional on GCC version

### DIFF
--- a/benchmarks/bsw/utils.h
+++ b/benchmarks/bsw/utils.h
@@ -48,7 +48,7 @@
 
 #define xassert(cond, msg) if ((cond) == 0) _err_fatal_simple_core(__func__, msg)
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ < 11 && !defined(__clang__)
 #if defined(__i386__)
 static inline unsigned long long __rdtsc(void)
 {


### PR DESCRIPTION
Fixes #9