### PR TITLE
Getopts fix

### DIFF
--- a/benchmarks/chain/src/main.cpp
+++ b/benchmarks/chain/src/main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char **argv) {
     FILE *in, *out;
     std::string inputFileName, outputFileName;
 
-    char opt, numThreads = 1;
+    int opt, numThreads = 1;
     while ((opt = getopt(argc, argv, ":i:o:t:h")) != -1) {
         switch (opt) {
             case 'i': inputFileName = optarg; break;

--- a/benchmarks/phmm/PairHMMUnitTest.cpp
+++ b/benchmarks/phmm/PairHMMUnitTest.cpp
@@ -176,7 +176,7 @@ int main(int argc, char** argv) {
         std::cout << USAGE_MESSAGE;
         exit(EXIT_FAILURE);
     }
-    for (char c; (c = getopt_long(argc, argv, shortopts, longopts, NULL)) != -1;) {
+    for (int c; (c = getopt_long(argc, argv, shortopts, longopts, NULL)) != -1;) {
         switch (c) {
             case 'f': opt::testfile = optarg; break;
             case 'l': opt::loop = stoi(optarg); break;

--- a/benchmarks/poa/msa_spoa_omp.cpp
+++ b/benchmarks/poa/msa_spoa_omp.cpp
@@ -166,7 +166,7 @@ int main(int argc, char** argv) {
         exit(EXIT_FAILURE);
     }
 
-    char opt, *s; int n_seqs = 0, numThreads = 1;
+    char *s; int n_seqs = 0, numThreads = 1, opt;
     while ((opt = getopt(argc, argv, "l:m:x:o:n:e:q:c:s:t:h")) != -1) {
         switch (opt) {
             case 'm': m = atoi(optarg); break;


### PR DESCRIPTION
This patch fixes that the return value for getopt() in a number of the benchmarks is assigned to a char.  A char on x86 is signed, but unsigned on aarch64 - which breaks the "-1" check for end-of-options and leads to infinite loop.